### PR TITLE
Relax the JIRA Regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const chalk = require('chalk')
 const assert = require('assert')
 
 const DEFAULT_FILE = 'CHANGES.md'
-const JIRA_REGEX = /(?:)([A-Z]{1,}-[0-9]+)(?=\s|_|\/|$)/g
+const JIRA_REGEX = /(?:)([A-Z0-9]{1,}-[0-9]+)(?=\s|_|\/|$)/g
 
 let settings
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const chalk = require('chalk')
 const assert = require('assert')
 
 const DEFAULT_FILE = 'CHANGES.md'
-const JIRA_REGEX = /(?:)([A-Z0-9]{1,}-[0-9]+)(?=\s|_|\/|$)/g
+const JIRA_REGEX = /(?:)([A-Z0-9]{1,}-[0-9]+)(?=\s|-|_|\/|$)/g
 
 let settings
 


### PR DESCRIPTION
Relaxes the `JIRA_REGEX` so that:

* JIRA project keys with numbers are matched (e.g. "FOO2-1234")
* branch names which use "-" to separate the JIRA project key from the rest of the branch name are matched (e.g. "feature/FOO2-1234-awesome-stuff")